### PR TITLE
fix: support structural Handlebars in cookbook discovery

### DIFF
--- a/src/cache/cas/local.rs
+++ b/src/cache/cas/local.rs
@@ -402,11 +402,10 @@ impl BlobStore for LocalBlobStore {
         file.read_to_end(&mut buffer).await?;
 
         // Update access time in index if available (for LRU tracking)
-        if let Some(index) = &self.index {
-            if let Err(e) = index.touch(hash) {
+        if let Some(index) = &self.index
+            && let Err(e) = index.touch(hash) {
                 warn!("Failed to update access time for {}: {}", hash, e);
             }
-        }
 
         debug!("Retrieved blob {} ({} bytes)", hash, buffer.len());
         Ok(Bytes::from(buffer))
@@ -469,11 +468,10 @@ impl BlobStore for LocalBlobStore {
         }
 
         // Update index if available
-        if let Some(index) = &self.index {
-            if let Err(e) = index.insert(&hash, size) {
+        if let Some(index) = &self.index
+            && let Err(e) = index.insert(&hash, size) {
                 warn!("Failed to update index for {}: {}", hash, e);
             }
-        }
 
         debug!("Stored blob {} ({} bytes)", hash, content.len());
         Ok(hash)
@@ -486,11 +484,10 @@ impl BlobStore for LocalBlobStore {
             fs::remove_file(&path).await?;
 
             // Remove from index if available
-            if let Some(index) = &self.index {
-                if let Err(e) = index.remove(hash) {
+            if let Some(index) = &self.index
+                && let Err(e) = index.remove(hash) {
                     warn!("Failed to remove {} from index: {}", hash, e);
                 }
-            }
 
             debug!("Deleted blob {}", hash);
         }

--- a/src/project/helper.rs
+++ b/src/project/helper.rs
@@ -100,17 +100,15 @@ impl Helper {
         })?;
 
         // Validate that filename matches helper name
-        if let Some(file_stem) = path.file_stem() {
-            if let Some(file_name) = file_stem.to_str() {
-                if file_name != helper.name {
+        if let Some(file_stem) = path.file_stem()
+            && let Some(file_name) = file_stem.to_str()
+                && file_name != helper.name {
                     bail!(
                         "Helper Load: Helper name '{}' doesn't match filename '{}'. They must be identical.",
                         helper.name,
                         file_name
                     );
                 }
-            }
-        }
 
         helper.helper_path = path.clone();
         Ok(helper)

--- a/src/project/recipe.rs
+++ b/src/project/recipe.rs
@@ -114,8 +114,8 @@ impl Recipe {
             .unwrap_or_else(|_| self.config_path.parent().unwrap().to_path_buf());
         let mut file_hashes = BTreeMap::<PathBuf, String>::new();
 
-        if let Some(cache) = &self.cache {
-            if !cache.inputs.is_empty() {
+        if let Some(cache) = &self.cache
+            && !cache.inputs.is_empty() {
                 // Group patterns by their walk roots (performance optimization)
                 let pattern_groups =
                     self.group_patterns_by_walk_root(&cache.inputs, &cookbook_dir)?;
@@ -126,7 +126,6 @@ impl Recipe {
                     self.walk_and_hash(&walk_root, &patterns, &cookbook_dir, &mut file_hashes)?;
                 }
             }
-        }
 
         // Add environment variables
         let environment = self

--- a/src/update.rs
+++ b/src/update.rs
@@ -154,39 +154,35 @@ pub fn perform_self_update(prerelease: bool) -> Result<()> {
     let current_version = cargo_crate_version!();
 
     // Check if this is a package-managed installation
-    if let Ok(current_exe) = env::current_exe() {
-        if is_package_managed_installation(&current_exe) {
-            println!(
-                "{}",
-                style("Cannot update: bake is installed via a package manager.").yellow()
-            );
-            println!(
-                "{}",
-                style("Please use your package manager to update:").dim()
-            );
+    if let Ok(current_exe) = env::current_exe()
+        && is_package_managed_installation(&current_exe)
+    {
+        println!(
+            "{}",
+            style("Cannot update: bake is installed via a package manager.").yellow()
+        );
+        println!(
+            "{}",
+            style("Please use your package manager to update:").dim()
+        );
 
-            let exe_path = current_exe.to_string_lossy();
-            if exe_path.contains("/opt/homebrew/") || exe_path.contains("/home/linuxbrew/") {
-                println!("  {}", style("brew upgrade bake").cyan());
-            } else if exe_path.contains("/usr/bin/")
-                && std::path::Path::new("/usr/bin/apt").exists()
-            {
-                println!(
-                    "  {}",
-                    style("sudo apt update && sudo apt upgrade bake").cyan()
-                );
-            } else if exe_path.contains("/usr/bin/")
-                && std::path::Path::new("/usr/bin/yum").exists()
-            {
-                println!("  {}", style("sudo yum update bake").cyan());
-            } else if exe_path.contains("/snap/") {
-                println!("  {}", style("sudo snap refresh bake").cyan());
-            } else {
-                println!("  {}", style("Use your system's package manager").cyan());
-            }
-
-            return Ok(());
+        let exe_path = current_exe.to_string_lossy();
+        if exe_path.contains("/opt/homebrew/") || exe_path.contains("/home/linuxbrew/") {
+            println!("  {}", style("brew upgrade bake").cyan());
+        } else if exe_path.contains("/usr/bin/") && std::path::Path::new("/usr/bin/apt").exists() {
+            println!(
+                "  {}",
+                style("sudo apt update && sudo apt upgrade bake").cyan()
+            );
+        } else if exe_path.contains("/usr/bin/") && std::path::Path::new("/usr/bin/yum").exists() {
+            println!("  {}", style("sudo yum update bake").cyan());
+        } else if exe_path.contains("/snap/") {
+            println!("  {}", style("sudo snap refresh bake").cyan());
+        } else {
+            println!("  {}", style("Use your system's package manager").cyan());
         }
+
+        return Ok(());
     }
 
     // Check if we have write permissions


### PR DESCRIPTION
## Summary

- Replace `load_minimal` with `load_for_discovery` to properly handle cookbooks using structural Handlebars (e.g., `{{#if}}` blocks around recipe definitions)
- Update `discover_all` to accept `VariableContext` for template rendering during discovery
- Include clippy fixes using let-chains for cleaner conditionals

## Problem

The previous `load_minimal` approach parsed raw YAML without Handlebars rendering, which failed for cookbooks using structural Handlebars like:

```yaml
recipes:
  {{#if var.enable_cache}}
  cached-build:
    run: echo "cached"
  {{/if}}
```

This is invalid YAML until the Handlebars template is rendered.

## Solution

The new `load_for_discovery` method:
1. Extracts variables from raw YAML text (before parsing)
2. Processes cookbook variables with project context
3. Renders the full YAML with Handlebars
4. Parses only essential fields (name, dependencies, tags)

This mirrors how `bake.yml` already handles the same problem.

## Test plan

- [x] All 372 tests pass
- [x] No clippy warnings
- [x] Tested on real project (quasar) with structural Handlebars in `bake.yml`
- [x] CodeRabbit review passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added targeted upgrade guidance for package-managed installations, with specific instructions for Homebrew, APT, YUM, and Snap.
  * Implemented faster cookbook discovery with template-aware metadata extraction for improved initialization performance.

* **Refactoring**
  * Simplified control flow by consolidating nested conditionals into combined conditions throughout the codebase.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->