### PR TITLE
fix: store action cache manifests in remote blob stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Bake
 
+## v2.0.2 - 2026-01-08
+
+### Fixed
+
+- **Remote manifest storage for CI cache sharing** - Action cache manifests are now stored in remote blob stores (S3/GCS)
+  - Previously, manifests were stored locally only, causing cache misses on fresh CI machines
+  - Manifests are now uploaded alongside blobs for full cache portability across machines
+  - Respects configured cache order (LocalFirst vs RemoteFirst)
+  - Automatic promotion: manifests fetched from remote are cached locally
+
 ## v2.0.1 - 2026-01-06
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -577,7 +577,7 @@ dependencies = [
 
 [[package]]
 name = "bake-cli"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bake-cli"
-version = "2.0.1"
+version = "2.0.2"
 edition = "2024"
 authors = ["Theo Ribeiro <repitilian.intern@proton.me>"]
 license = "Apache-2.0"

--- a/src/cache/cas/blob_store.rs
+++ b/src/cache/cas/blob_store.rs
@@ -56,6 +56,20 @@ pub trait BlobStore: Send + Sync {
 
     /// List all blob hashes in the store (for debugging/maintenance)
     async fn list(&self) -> Result<Vec<BlobHash>>;
+
+    /// Store a manifest (action result) at a specific key
+    /// This is NOT content-addressed - the key is used directly as the path
+    /// Default implementation does nothing (local-only stores don't need remote manifest storage)
+    async fn put_manifest(&self, _key: &str, _content: Bytes) -> Result<()> {
+        Ok(())
+    }
+
+    /// Get a manifest (action result) by key
+    /// Returns None if not found
+    /// Default implementation returns None (local-only stores don't use remote manifests)
+    async fn get_manifest(&self, _key: &str) -> Result<Option<Bytes>> {
+        Ok(None)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Fix CI cache sharing by storing action cache manifests in remote blob stores (S3/GCS)
- Previously manifests were local-only, causing cache misses on fresh CI machines
- Manifests are now uploaded alongside blobs for full cache portability

## Test plan

- [x] All 340 unit tests pass
- [x] Clippy passes with no warnings
- [ ] Manual testing in CI environment to verify cross-machine cache hits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed remote manifest storage for CI cache sharing, enabling manifests to be stored and retrieved from remote blob stores (S3/GCS) for improved cache portability across CI environments.
  * Added automatic promotion of remote-fetched manifests to local cache for enhanced performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->