### PR TITLE
fix: blobs not uploaded to remote cache in layered store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Bake
 
+## v2.0.3 - 2026-01-08
+
+### Fixed
+
+- **Blobs not uploaded to remote cache** - Fixed critical bug where blobs were stored locally only even when S3/GCS was configured
+  - With layered cache (local + remote), manifests were uploaded to S3 but blobs stayed local
+  - This caused cache misses in CI when other machines tried to restore from remote
+  - Layered blob store now always writes to all tiers for consistency with manifest behavior
+  - Removed the confusing `write_through` option - writes always go to all configured tiers
+
 ## v2.0.2 - 2026-01-08
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -577,7 +577,7 @@ dependencies = [
 
 [[package]]
 name = "bake-cli"
-version = "2.0.2"
+version = "2.0.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bake-cli"
-version = "2.0.2"
+version = "2.0.3"
 edition = "2024"
 authors = ["Theo Ribeiro <repitilian.intern@proton.me>"]
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

- Fixed critical bug where blobs were stored locally only even when S3/GCS was configured
- With layered cache (local + remote), manifests were uploaded to S3 but blobs stayed local, causing cache misses in CI
- Layered blob store now always writes to all tiers for consistency
- Removed the confusing `write_through` option - writes always go to all configured tiers

## Changes

- Simplified type from `Arc<Box<dyn BlobStore>>` to `Arc<dyn BlobStore>` 
- Added validation for non-empty tiers in constructors (returns `Result`)
- Added debug logging to `get()` and `get_many()` for better troubleshooting
- Added tests for `put_manifest`/`get_manifest` in layered store

## Test plan

- [x] All existing tests pass
- [x] New unit tests for empty tier validation
- [x] New unit tests for manifest operations in layered store
- [x] Clippy passes with no warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Blobs now write to all configured cache tiers in layered setups (previously could remain local), aligning blob behavior with manifests.

* **New Features**
  * Manifest read/write operations now support multi-tier storage with promotion to faster tiers on access.

* **Tests**
  * Added comprehensive tests for multi-tier writes, promotion behavior, and manifest storage/retrieval.

* **Chores**
  * Release bumped to v2.0.3.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->