### PR TITLE
chore: dogfood bake locally in the bake repo

### DIFF
--- a/.bakeignore
+++ b/.bakeignore
@@ -1,0 +1,2 @@
+resources/tests/
+target/

--- a/bake.yml
+++ b/bake.yml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=./schemas/bake-project.schema.json
+name: bake
+description: Dogfood Bake against the Bake repository itself
+
+environment:
+  - CI
+  - RUST_LOG
+  - CARGO_TERM_COLOR
+
+config:
+  minVersion: "2.1.0"
+  verbose: true

--- a/cookbook.yml
+++ b/cookbook.yml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=./schemas/cookbook.schema.json
+name: repo
+tags:
+  - rust
+  - dogfood
+
+recipes:
+  build:
+    description: Build Bake
+    run: cargo build
+
+  fmt:
+    description: Check Rust formatting
+    run: cargo fmt --check
+
+  lint:
+    description: Run clippy for Bake
+    run: cargo clippy --all-targets
+
+  test-lib:
+    description: Run Bake library tests
+    run: cargo test --lib
+
+  check:
+    description: Run the core dogfood checks for Bake
+    dependencies:
+      - build
+      - fmt
+      - lint
+      - test-lib
+    run: echo "Bake dogfood checks completed"

--- a/cookbook.yml
+++ b/cookbook.yml
@@ -21,6 +21,10 @@ recipes:
     description: Run Bake library tests
     run: cargo test --lib
 
+  test-integration:
+    description: Run Bake integration tests
+    run: cargo test --tests
+
   check:
     description: Run the core dogfood checks for Bake
     dependencies:
@@ -28,4 +32,5 @@ recipes:
       - fmt
       - lint
       - test-lib
+      - test-integration
     run: echo "Bake dogfood checks completed"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "stable"
+channel = "1.93.0"


### PR DESCRIPTION
## Summary
- add a local Bake project and cookbook for the Bake repository itself
- add repo-scoped build, fmt, lint, and test dogfood recipes
- pin the Rust toolchain used for local dogfooding

## Notes
- this is only for local dogfooding in the repository
- there are no CI or release pipeline changes in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added Bake build system configuration including environment variables and ignore patterns to exclude build artifacts and test resources.
  * Introduced named development recipes for building, formatting, linting, library and integration tests, plus a composite check that runs them in order.
  * Locked Rust compiler toolchain to version 1.93.0 for consistent builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->