### PR TITLE
feat: add bake skills to the repo

### DIFF
--- a/.claude/skills/bake/SKILL.md
+++ b/.claude/skills/bake/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: bake
+description: Use when this repository relies on Bake as its task runner. Prefer Bake recipes over raw cargo, go, npm, or other tool commands when a matching recipe exists. Read the project-specific Bake reference before choosing commands.
+---
+
+# Bake
+
+Treat Bake as the canonical task runner for this repository.
+
+## Workflow
+
+- Read [project-specific-skill.md](references/project-specific-skill.md) before suggesting or running commands.
+- If the repository defines a Bake recipe for a task such as build, test, lint, or release, prefer the Bake recipe over the underlying tool command.
+- For example, if the reference shows a test recipe for a cookbook or domain, use `bake <cookbook>:test` instead of jumping straight to `cargo test`, `go test`, `npm test`, or similar raw commands.
+- Bake resolves recipe dependencies automatically. If `bake app:test` depends on `app:build` or setup recipes, select `app:test` and let Bake schedule the prerequisites.
+- Do not manually run prerequisite Bake recipes before the target unless the user explicitly asks for that narrower step.
+- Prefer targeted selectors: `bake <cookbook>:<recipe>` for one recipe, `bake <cookbook>:` for one cookbook scope, and `bake :<recipe>` for the same recipe across multiple cookbooks.
+- Prefer `bake --show-plan ...` before broad or unfamiliar runs.
+- Use `bake --dry-run` when the user wants a preview without execution.
+- Use `--env <name>`, `-D key=value`, `--tags`, and `--regex` only when they materially change the selection.
+- Fall back to raw tool commands only when no suitable Bake recipe exists or the user explicitly asks to bypass Bake.
+- If you update Bake cookbooks, recipes, templates, or helpers, regenerate this skill with `bake --generate skill`.
+
+## Reference
+
+- For repository-specific cookbook names, recipes, environments, templates, helpers, and examples, read [project-specific-skill.md](references/project-specific-skill.md).

--- a/.claude/skills/bake/references/project-specific-skill.md
+++ b/.claude/skills/bake/references/project-specific-skill.md
@@ -1,0 +1,30 @@
+# Project-Specific Bake Reference
+
+This repository uses Bake to define project tasks in `bake.yml` and cookbook files. A cookbook is the project-local scope or domain used in selectors like `foo:build`.
+
+Project: `bake`. Dogfood Bake against the Bake repository itself
+
+## Targeting Recipes
+- `bake repo:build` runs a single recipe inside one cookbook.
+- `bake repo:` runs every recipe in that cookbook.
+- `bake :<recipe>` runs the same recipe across every cookbook that defines it.
+- Bake resolves declared dependencies automatically, so selecting a target recipe also schedules its prerequisite recipes.
+- Add `--regex` to treat both sides of `cookbook:recipe` as regular expressions.
+- Add `--tags <tag1,tag2>` to match recipes that carry any of those tags.
+- Use `--show-plan`, `--dry-run`, `--clean`, `--env <name>`, and `-D key=value` when you need planning, cleanup, environment selection, or variable overrides.
+
+## Project Inventory
+- Project name: `bake`
+- Cookbooks: `repo`
+- Project environment variables exposed to recipes: `CI`, `RUST_LOG`, `CARGO_TERM_COLOR`
+
+## Cookbook Scopes
+
+### `repo`
+Inherited cookbook tags: `rust`, `dogfood`
+- `repo:build`: Build Bake. tags: `rust`, `dogfood`
+- `repo:check`: Run the core dogfood checks for Bake. tags: `rust`, `dogfood`. depends on `repo:build`, `repo:fmt`, `repo:lint`, `repo:test-lib`, `repo:test-integration`
+- `repo:fmt`: Check Rust formatting. tags: `rust`, `dogfood`
+- `repo:lint`: Run clippy for Bake. tags: `rust`, `dogfood`
+- `repo:test-integration`: Run Bake integration tests. tags: `rust`, `dogfood`
+- `repo:test-lib`: Run Bake library tests. tags: `rust`, `dogfood`

--- a/.codex/skills/bake/SKILL.md
+++ b/.codex/skills/bake/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: bake
+description: Use when this repository relies on Bake as its task runner. Prefer Bake recipes over raw cargo, go, npm, or other tool commands when a matching recipe exists. Read the project-specific Bake reference before choosing commands.
+---
+
+# Bake
+
+Treat Bake as the canonical task runner for this repository.
+
+## Workflow
+
+- Read [project-specific-skill.md](references/project-specific-skill.md) before suggesting or running commands.
+- If the repository defines a Bake recipe for a task such as build, test, lint, or release, prefer the Bake recipe over the underlying tool command.
+- For example, if the reference shows a test recipe for a cookbook or domain, use `bake <cookbook>:test` instead of jumping straight to `cargo test`, `go test`, `npm test`, or similar raw commands.
+- Bake resolves recipe dependencies automatically. If `bake app:test` depends on `app:build` or setup recipes, select `app:test` and let Bake schedule the prerequisites.
+- Do not manually run prerequisite Bake recipes before the target unless the user explicitly asks for that narrower step.
+- Prefer targeted selectors: `bake <cookbook>:<recipe>` for one recipe, `bake <cookbook>:` for one cookbook scope, and `bake :<recipe>` for the same recipe across multiple cookbooks.
+- Prefer `bake --show-plan ...` before broad or unfamiliar runs.
+- Use `bake --dry-run` when the user wants a preview without execution.
+- Use `--env <name>`, `-D key=value`, `--tags`, and `--regex` only when they materially change the selection.
+- Fall back to raw tool commands only when no suitable Bake recipe exists or the user explicitly asks to bypass Bake.
+- If you update Bake cookbooks, recipes, templates, or helpers, regenerate this skill with `bake --generate skill`.
+
+## Reference
+
+- For repository-specific cookbook names, recipes, environments, templates, helpers, and examples, read [project-specific-skill.md](references/project-specific-skill.md).

--- a/.codex/skills/bake/references/project-specific-skill.md
+++ b/.codex/skills/bake/references/project-specific-skill.md
@@ -1,0 +1,30 @@
+# Project-Specific Bake Reference
+
+This repository uses Bake to define project tasks in `bake.yml` and cookbook files. A cookbook is the project-local scope or domain used in selectors like `foo:build`.
+
+Project: `bake`. Dogfood Bake against the Bake repository itself
+
+## Targeting Recipes
+- `bake repo:build` runs a single recipe inside one cookbook.
+- `bake repo:` runs every recipe in that cookbook.
+- `bake :<recipe>` runs the same recipe across every cookbook that defines it.
+- Bake resolves declared dependencies automatically, so selecting a target recipe also schedules its prerequisite recipes.
+- Add `--regex` to treat both sides of `cookbook:recipe` as regular expressions.
+- Add `--tags <tag1,tag2>` to match recipes that carry any of those tags.
+- Use `--show-plan`, `--dry-run`, `--clean`, `--env <name>`, and `-D key=value` when you need planning, cleanup, environment selection, or variable overrides.
+
+## Project Inventory
+- Project name: `bake`
+- Cookbooks: `repo`
+- Project environment variables exposed to recipes: `CI`, `RUST_LOG`, `CARGO_TERM_COLOR`
+
+## Cookbook Scopes
+
+### `repo`
+Inherited cookbook tags: `rust`, `dogfood`
+- `repo:build`: Build Bake. tags: `rust`, `dogfood`
+- `repo:check`: Run the core dogfood checks for Bake. tags: `rust`, `dogfood`. depends on `repo:build`, `repo:fmt`, `repo:lint`, `repo:test-lib`, `repo:test-integration`
+- `repo:fmt`: Check Rust formatting. tags: `rust`, `dogfood`
+- `repo:lint`: Run clippy for Bake. tags: `rust`, `dogfood`
+- `repo:test-integration`: Run Bake integration tests. tags: `rust`, `dogfood`
+- `repo:test-lib`: Run Bake library tests. tags: `rust`, `dogfood`


### PR DESCRIPTION
Add LLM skills to the repo (genereted with bake itself)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Bake task runner documentation establishing it as the canonical task executor. Includes guidance on recipe targeting semantics, selection modifiers (`--env`, `-D`, `--tags`, `--regex`), and recommended safe execution options like `--show-plan` and `--dry-run`. Also provides project-specific recipe inventory and dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->